### PR TITLE
Write api wrapper for domestic shipping rates and create first simple calculators

### DIFF
--- a/lib/solidus_usps.rb
+++ b/lib/solidus_usps.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'solidus_usps/configuration'
-require 'solidus_usps/version'
 require 'solidus_usps/engine'
+require 'solidus_usps/version'
+
+require 'solidus_usps/domestic_prices_client'
 require 'solidus_usps/oauth_client'
+require 'solidus_usps/rates_search_data'

--- a/lib/solidus_usps/calculator/base.rb
+++ b/lib/solidus_usps/calculator/base.rb
@@ -1,0 +1,10 @@
+module SolidusUsps
+  module Calculator
+    class Base < Spree::ShippingCalculator
+      def rates_search_data(spree_package)
+        SolidusUsps::RatesSearchData.new(spree_package)
+      end
+    end
+  end
+end
+

--- a/lib/solidus_usps/calculator/priority_mail.rb
+++ b/lib/solidus_usps/calculator/priority_mail.rb
@@ -1,0 +1,21 @@
+module SolidusUsps
+  module Calculator
+    class PriorityMail < SolidusUsps::Calculator::Base
+      def compute_package(package)
+        SolidusUsps::DomesticPricesClient.get_rates(rates_search_data(package))
+      end
+
+      def available? package
+        ship_to_country_code(package) == 'US' || package.weight > 4
+      end
+
+      private
+
+      def ship_to_country_code(package)
+        package.order.ship_address.country.iso
+      end
+    end
+  end
+end
+
+

--- a/lib/solidus_usps/domestic_prices_client.rb
+++ b/lib/solidus_usps/domestic_prices_client.rb
@@ -1,0 +1,33 @@
+module SolidusUsps
+  class DomesticPricesClient
+    class DomestricPricesError < StandardError; end
+
+    DOMESTIC_PRICES_ENDPOINT = "https://apis.usps.com/prices/v3/base-rates/search"
+
+    def initialize(oauth_client = nil)
+      @oauth_client = oauth_client || SolidusUsps::OauthClient.new
+    end
+
+    def get_rates(rates_search_data)
+      response = connection.post(DOMESTIC_PRICES_ENDPOINT) do |request|
+        request.headers["Authorization"] = "Bearer #{@oauth_client.access_token}"
+        request.headers["Content-Type"] = "application/json"
+        request.body = rates_search_data.to_json
+      end
+      
+      return response.body if response.success?
+
+      raise DomestricPricesError, "Error fetching rates: #{response.status} - #{response.body}"
+    end
+
+    private
+
+    def connection
+      @connection ||= Faraday.new(url: @oauth_client.config.base_url) do |connection|
+        connection.request :json
+        connection.response :json
+        connection.adapter :net_http
+      end
+    end
+  end
+end

--- a/lib/solidus_usps/engine.rb
+++ b/lib/solidus_usps/engine.rb
@@ -15,5 +15,10 @@ module SolidusUsps
     config.generators do |g|
       g.test_framework :rspec
     end
+
+    config.after_initialize do
+      require 'solidus_usps/calculator/base'
+      require 'solidus_usps/calculator/priority_mail'
+    end
   end
 end

--- a/lib/solidus_usps/rates_search_data.rb
+++ b/lib/solidus_usps/rates_search_data.rb
@@ -1,0 +1,41 @@
+module SolidusUsps
+  class RatesSearchData
+    def initialize(spree_package)
+      @spree_package = spree_package
+    end
+
+    def to_json
+      {
+        'originZIPCode' => origin_zipcode,
+        'destinationZIPCode' => destination_zipcode,
+        'weight' => weight,
+        'length' => nil,
+        'width' => nil,
+        'height' => nil,
+        'mailClass' => nil,
+        'processingCategory' => nil,
+        'rateIndicator' => nil,
+        'destinationEntryFacilityType' => nil,
+        'priceType' => nil,
+        'mailingDate' => nil, # Optional.
+        'accountType' => nil, # Optional.
+        'accountNumber' => nil, # Optional.
+        'hasNonstandardCharacteristics' => nil, # Optional.
+      }.to_json
+    end
+
+    private
+
+    def origin_zipcode
+      @spree_package.stock_location.zipcode
+    end
+
+    def destination_zipcode
+      @spree_package.order&.ship_address&.zipcode
+    end
+
+    def weight
+      @spree_package.weight
+    end
+  end
+end

--- a/spec/lib/solidus_usps/calculator/base_spec.rb
+++ b/spec/lib/solidus_usps/calculator/base_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe SolidusUsps::Calculator::Base do
+  subject { described_class.new }
+
+  let(:stock_location) { create(:stock_location, zipcode: "12345") }
+  let(:order) { create(:order, ship_address: create(:address, zipcode: "67890")) }
+  let(:variant) { create(:variant, weight: 10.0) }
+  let(:line_item) { create(:line_item, order: order, variant: variant, quantity: 1) }
+  let(:inventory_unit) { create(:inventory_unit, line_item: line_item, order: order, variant: variant) }
+
+  let(:spree_package) do
+    build(:stock_package, stock_location: stock_location).tap do |package|
+      package.add(inventory_unit)
+    end
+  end
+
+  describe "#rates_search_data" do
+    it "returns a SolidusUsps::RatesSearchData object built from the package" do
+      result = subject.rates_search_data(spree_package)
+
+      expect(result).to be_a(SolidusUsps::RatesSearchData)
+      expect(result.to_json).to include("12345", "67890", "10.0")
+    end
+  end
+end

--- a/spec/lib/solidus_usps/calculator/priority_mail_spec.rb
+++ b/spec/lib/solidus_usps/calculator/priority_mail_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe SolidusUsps::Calculator::PriorityMail do
+  subject(:calculator) { described_class.new }
+
+  let(:stock_location) { create(:stock_location, zipcode: "12345") }
+  let(:variant) { create(:variant, weight: 2.0) }
+  let(:line_item) { create(:line_item, order: order, variant: variant, quantity: 1) }
+  let(:inventory_unit) {
+    create(:inventory_unit, line_item: line_item, order: order, variant: variant)
+  }
+  let(:spree_package) do
+    build(:stock_package, stock_location: stock_location).tap do |package|
+      package.add(inventory_unit)
+    end
+  end
+
+  describe "#compute_package" do
+    let(:order) { create(:order, ship_address: create(:address, zipcode: "67890")) }
+    let(:rates_search_data) { instance_double(SolidusUsps::RatesSearchData) }
+
+    before do
+      allow(calculator).to receive(:rates_search_data).and_return(rates_search_data)
+      allow(SolidusUsps::DomesticPricesClient).to receive(:get_rates).and_return("some response")
+    end
+
+    it "calls DomesticPricesClient with rates search data" do
+      calculator.compute_package(spree_package)
+      expect(SolidusUsps::DomesticPricesClient).to have_received(:get_rates).with(rates_search_data)
+    end
+  end
+
+  describe "#available?" do
+    context "when shipping to the US" do
+      let(:us) { Spree::Country.find_or_create_by(iso: 'US', name: 'United States') }
+      let(:order) { create(:order, ship_address: create(:address, country: us)) }
+
+      it "returns true" do
+        expect(calculator.available?(spree_package)).to eq true
+      end
+    end
+
+    context "when shipping internationally" do
+      let(:canada) { Spree::Country.find_or_create_by(iso: 'CA', name: 'Canada') }
+      let(:order) { create(:order, ship_address: create(:address, country: canada)) }
+
+      context "when package weight is 4 or less" do
+        let(:variant) { create(:variant, weight: 4.0) }
+
+        it "returns false" do
+          expect(calculator.available?(spree_package)).to be false
+        end
+      end
+
+      context "when package weight is more than 4" do
+        let(:variant) { create(:variant, weight: 5.0) }
+
+        it "returns true" do
+          expect(calculator.available?(spree_package)).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_usps/domestic_prices_client_spec.rb
+++ b/spec/lib/solidus_usps/domestic_prices_client_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe SolidusUsps::DomesticPricesClient do
+  describe '#get_rates' do
+    let(:oauth_client) { double('OauthClient', access_token: access_token, config: config) }
+    let(:access_token) { 'test_access_token' }
+    let(:client) { described_class.new(oauth_client) }
+    let(:rates_search_data) { { originZIPCode: '54321' } }
+    let(:connection) { instance_double(Faraday::Connection) }
+    let(:config) { double('config', base_url: 'https://apis.usps.com') }
+
+    before do
+      allow(oauth_client).to receive(:access_token).and_return(access_token)
+      allow(oauth_client).to receive(:config).and_return(config)
+      allow(Faraday).to receive(:new).and_return(connection)
+    end
+
+    context "when the request is successful" do
+      let(:success_response) {
+        instance_double(Faraday::Response, success?: true, body: { "price" => "5.00" }, status: 200)
+      }
+
+      before do
+        allow(connection).to receive(:post).and_return(success_response)
+      end
+
+      it "returns the response body" do
+        expect(client.get_rates(rates_search_data))
+          .to eq({ "price" => "5.00" })
+      end
+    end
+
+    context 'when the request is unsuccessful' do
+      let(:error_response) {
+        instance_double(Faraday::Response, success?: false, body: 'Error message', status: 500)
+      }
+
+      before do
+        allow(connection).to receive(:post).and_return(error_response)
+      end
+
+      it 'raises a DomesticPricesError' do
+        expect { client.get_rates(rates_search_data) }
+          .to raise_error(
+            SolidusUsps::DomesticPricesClient::DomestricPricesError, /Error fetching rates: 500 - Error message/
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_usps/rates_search_data_spec.rb
+++ b/spec/lib/solidus_usps/rates_search_data_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe SolidusUsps::RatesSearchData do
+  subject { described_class.new(spree_package) }
+
+  let(:stock_location) { create(:stock_location, zipcode: "12345") }
+  let(:order) { create(:order, ship_address: create(:address, zipcode: "67890")) }
+  let(:variant) { create(:variant, weight: 10.0) }
+  let(:line_item) { create(:line_item, order: order, variant: variant, quantity: 1) }
+  let(:inventory_unit) { create(:inventory_unit, line_item: line_item, order: order, variant: variant) }
+
+  let(:spree_package) do
+    build(:stock_package, stock_location: stock_location).tap do |package|
+      package.add(inventory_unit)
+    end
+  end
+
+  describe '#to_json' do
+    it "returns a JSON string with the correct structure" do
+      json_data = JSON.parse(subject.to_json)
+
+      expect(json_data).to include(
+        'originZIPCode' => "12345",
+        'destinationZIPCode' => "67890",
+        'weight' => "10.0",
+        'length' => nil,
+        'width' => nil,
+        'height' => nil,
+        'mailClass' => nil,
+        'processingCategory' => nil,
+        'rateIndicator' => nil,
+        'destinationEntryFacilityType' => nil,
+        'priceType' => nil,
+        'mailingDate' => nil,
+        'accountType' => nil,
+        'accountNumber' => nil,
+        'hasNonstandardCharacteristics' => nil
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is intended as an mvp for the domestic shipping rates USPS api. I don't fully know yet what all the fields we need to send are going to look like, so there are some TODO's to double back on. The rates search data object might also change, as I intend to hopefully resuse it for the international shipping rates client.

**_Edit:_**
I added the work for 'Write SolidusUsps::Calculator::PriorityMail calculator' (TJ 216) into this PR because it makes sense (also see Jared's feedback). I initially wrote the api wrappers to take in spree addresses/shipments but due to the nature of the Spree::Calculator, it should have been a package. It's been re-written now to account for that.