### PR TITLE
Add basic USPS Ground Advantage calculator

### DIFF
--- a/lib/solidus_usps/calculator/ground_advantage.rb
+++ b/lib/solidus_usps/calculator/ground_advantage.rb
@@ -1,0 +1,34 @@
+module SolidusUsps
+  module Calculator
+    # Originally, FirstClassMailParcel. That service was discontinued in 2023
+    # and renamed/merged into USPS Ground Advantage.
+    class GroundAdvantage < SolidusUsps::Calculator::Base
+      # Maximum weight in ounces. Copied over from the old first class mail
+      # parcel so we may need to update this value.
+      MAXIMUM_WEIGHT = 13
+
+      def compute_package(package)
+        client = SolidusUsps::DomesticPricesClient.new
+        client.get_rates(rates_search_data(package))
+      end
+
+      def available? package
+        ship_to_country_code(package) == 'US' && package.weight <= MAXIMUM_WEIGHT && super
+      end
+
+      private
+
+      def ship_to_country_code(package)
+        package.order.ship_address.country.iso
+      end
+
+      def search_data_class
+        SolidusUsps::DomesticRatesSearchData
+      end
+
+      def mail_class
+        :USPS_GROUND_ADVANTAGE
+      end
+    end
+  end
+end

--- a/lib/solidus_usps/engine.rb
+++ b/lib/solidus_usps/engine.rb
@@ -19,6 +19,7 @@ module SolidusUsps
     config.after_initialize do
       require 'solidus_usps/calculator/base'
       require 'solidus_usps/calculator/first_class_package_international'
+      require 'solidus_usps/calculator/ground_advantage'
       require 'solidus_usps/calculator/priority_mail'
       require 'solidus_usps/calculator/priority_mail_with_insurance'
     end

--- a/spec/lib/solidus_usps/calculator/ground_advantage_spec.rb
+++ b/spec/lib/solidus_usps/calculator/ground_advantage_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+RSpec.describe SolidusUsps::Calculator::GroundAdvantage do
+  subject(:calculator) { described_class.new }
+
+  let(:order) { create(:order_ready_to_ship, ship_address: shipping_address) }
+  let(:shipping_address) { create(:address, country: create(:country, iso: iso)) }
+  let(:iso) { 'US' }
+  let(:package) { order.shipments.first.to_package }
+
+  describe "#compute_package" do
+    let(:client) { instance_double(SolidusUsps::DomesticPricesClient) }
+
+    before do
+      allow(SolidusUsps::DomesticPricesClient).to receive(:new).and_return(client)
+      allow(client).to receive(:get_rates).and_return("some response")
+    end
+
+    it "calls DomesticPricesClient with rates search data" do
+      calculator.compute_package(package)
+      expect(client).to have_received(:get_rates)
+    end
+  end
+
+  describe "#available?" do
+    context "shipping to the US" do
+      context "with a package weight of 13 or less" do
+        before do
+          order.variants.each { |variant| variant.update!(weight: 2) }
+        end
+
+        it "is available" do
+          expect(calculator.available?(package)).to eq true
+        end
+      end
+
+      context "with a package weight over 13" do
+        before do
+          order.variants.each { |variant| variant.update!(weight: 15) }
+        end
+
+        it "is unavailable" do
+          expect(calculator.available?(package)).to eq false
+        end
+      end
+    end
+
+    context "shipping internationally" do
+      let(:iso) { 'CA' }
+
+      it "is unavailable" do
+        expect(calculator.available?(package)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This calculator will replace the old FirstClassMailParcel one that existed in solidus_active_shipping. That delivery option was renamed and merged into USPS Ground Advantage in 2023.

We'll likely still need to do a little bit more work ensuring the weight limit is accurate for the new method and need some separate work to ensure we're sending all of the required information along to USPS in our API calls. (e.g.: Mail class is defined here but not used yet.)
