### PR TITLE
Add support for mail_class to calculators

### DIFF
--- a/lib/solidus_usps/base_rates_search_data.rb
+++ b/lib/solidus_usps/base_rates_search_data.rb
@@ -1,10 +1,15 @@
 module SolidusUsps
   class BaseRatesSearchData
-    def initialize(spree_package)
+    def initialize(calculator, spree_package)
+      @calculator = calculator
       @spree_package = spree_package
     end
 
     private
+
+    def mail_class
+      @calculator.mail_class
+    end
 
     def origin_zipcode
       @spree_package.stock_location.zipcode

--- a/lib/solidus_usps/calculator/base.rb
+++ b/lib/solidus_usps/calculator/base.rb
@@ -2,10 +2,14 @@ module SolidusUsps
   module Calculator
     class Base < Spree::ShippingCalculator
       def rates_search_data(spree_package)
-        search_data_class.new(spree_package)
+        search_data_class.new(self, spree_package)
       end
 
       private
+
+      def mail_class
+        raise NotImplementedError, "Subclasses must implement the mail_class method"
+      end
 
       def search_data_class
         raise NotImplementedError, "Subclasses must implement the search_data_class method"

--- a/lib/solidus_usps/calculator/first_class_package_international.rb
+++ b/lib/solidus_usps/calculator/first_class_package_international.rb
@@ -4,11 +4,8 @@ module SolidusUsps
   module Calculator
     class FirstClassPackageInternational < SolidusUsps::Calculator::Base
       def compute_package(package)
-        data = rates_search_data(package)
-        client = SolidusUsps::InternationalPricesClient.new(
-          oauth_client: SolidusUsps::OauthClient.new
-        )
-        client.get_rates(data)
+        client = SolidusUsps::InternationalPricesClient.new
+        client.get_rates(rates_search_data(package))
       end
 
       def available? package
@@ -23,6 +20,10 @@ module SolidusUsps
 
       def ship_to_country_code(package)
         package.order.ship_address.country.iso
+      end
+
+      def search_data_class
+        SolidusUsps::InternationalRatesSearchData
       end
     end
   end

--- a/lib/solidus_usps/calculator/first_class_package_international.rb
+++ b/lib/solidus_usps/calculator/first_class_package_international.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusUsps
   module Calculator
     class FirstClassPackageInternational < SolidusUsps::Calculator::Base
@@ -11,6 +13,10 @@ module SolidusUsps
 
       def available? package
         ship_to_country_code(package) == 'US' && package.weight <= 4 && super
+      end
+
+      def mail_class
+        "FIRST-CLASS_PACKAGE_INTERNATIONAL_SERVICE"
       end
 
       private

--- a/lib/solidus_usps/calculator/priority_mail.rb
+++ b/lib/solidus_usps/calculator/priority_mail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusUsps
   module Calculator
     class PriorityMail < SolidusUsps::Calculator::Base
@@ -11,6 +13,10 @@ module SolidusUsps
 
       def available? package
         ship_to_country_code(package) == 'US' || package.weight > 4
+      end
+
+      def mail_class
+        "PRIORITY_MAIL"
       end
 
       private

--- a/lib/solidus_usps/calculator/priority_mail.rb
+++ b/lib/solidus_usps/calculator/priority_mail.rb
@@ -4,11 +4,8 @@ module SolidusUsps
   module Calculator
     class PriorityMail < SolidusUsps::Calculator::Base
       def compute_package(package)
-        data = rates_search_data(package)
-        client = SolidusUsps::DomesticPricesClient.new(
-          oauth_client: SolidusUsps::OauthClient.new
-        )
-        client.get_rates(data)
+        client = SolidusUsps::DomesticPricesClient.new
+        client.get_rates(rates_search_data(package))
       end
 
       def available? package

--- a/lib/solidus_usps/domestic_rates_search_data.rb
+++ b/lib/solidus_usps/domestic_rates_search_data.rb
@@ -8,7 +8,7 @@ module SolidusUsps
         'length' => nil,
         'width' => nil,
         'height' => nil,
-        'mailClass' => nil,
+        'mailClass' => mail_class,
         'processingCategory' => nil,
         'rateIndicator' => nil,
         'destinationEntryFacilityType' => nil,
@@ -20,7 +20,7 @@ module SolidusUsps
       }.to_json
     end
 
-    private 
+    private
 
     def destination_zipcode
       @spree_package.order&.ship_address&.zipcode

--- a/lib/solidus_usps/international_rates_search_data.rb
+++ b/lib/solidus_usps/international_rates_search_data.rb
@@ -7,7 +7,7 @@ module SolidusUsps
         'length' => nil,
         'width' => nil,
         'height' => nil,
-        'mailClass' => nil,
+        'mailClass' => mail_class,
         'processingCategory' => nil,
         'rateIndicator' => nil,
         'destinationEntryFacilityType' => nil,

--- a/spec/lib/solidus_usps/calculator/first_class_package_international_spec.rb
+++ b/spec/lib/solidus_usps/calculator/first_class_package_international_spec.rb
@@ -12,26 +12,17 @@ RSpec.describe SolidusUsps::Calculator::FirstClassPackageInternational do
   let(:spree_package) { order.shipments.first.to_package }
 
   describe "#compute_package" do
-    let(:rates_search_data) { instance_double(SolidusUsps::InternationalRatesSearchData) }
     let(:client) { instance_double(SolidusUsps::InternationalPricesClient) }
 
     before do
-      allow(calculator).to receive(:rates_search_data).and_return(rates_search_data)
-      allow(SolidusUsps::InternationalPricesClient)
-        .to receive(:new)
-        .with(
-          oauth_client: instance_of(SolidusUsps::OauthClient)
-        ).and_return(client)
-
+      allow(SolidusUsps::InternationalPricesClient).to receive(:new).and_return(client)
       allow(client).to receive(:get_rates).and_return("some response")
     end
 
     it "calls InternationalPricesClient with rates search data" do
       calculator.compute_package(spree_package)
-      expect(SolidusUsps::InternationalPricesClient)
-        .to have_received(:new)
-        .with(oauth_client: instance_of(SolidusUsps::OauthClient))
 
+      expect(SolidusUsps::InternationalPricesClient).to have_received(:new)
       expect(client).to have_received(:get_rates)
     end
   end

--- a/spec/lib/solidus_usps/calculator/priority_mail_spec.rb
+++ b/spec/lib/solidus_usps/calculator/priority_mail_spec.rb
@@ -17,25 +17,17 @@ RSpec.describe SolidusUsps::Calculator::PriorityMail do
 
   describe "#compute_package" do
     let(:order) { create(:order, ship_address: create(:address, zipcode: "67890")) }
-    let(:rates_search_data) { instance_double(SolidusUsps::DomesticRatesSearchData) }
     let(:client) { instance_double(SolidusUsps::DomesticPricesClient) }
 
     before do
-      allow(calculator).to receive(:rates_search_data).and_return(rates_search_data)
-
-      allow(SolidusUsps::DomesticPricesClient)
-        .to receive(:new)
-        .with(oauth_client: instance_of(SolidusUsps::OauthClient))
-        .and_return(client)
+      allow(SolidusUsps::DomesticPricesClient).to receive(:new).and_return(client)
 
       allow(client).to receive(:get_rates).and_return("some response")
     end
 
     it "calls DomesticPricesClient with rates search data" do
       calculator.compute_package(spree_package)
-      expect(SolidusUsps::DomesticPricesClient)
-        .to have_received(:new)
-        .with(oauth_client: instance_of(SolidusUsps::OauthClient))
+      expect(SolidusUsps::DomesticPricesClient).to have_received(:new)
 
       expect(client).to have_received(:get_rates)
     end

--- a/spec/lib/solidus_usps/domestic_rates_search_data_spec.rb
+++ b/spec/lib/solidus_usps/domestic_rates_search_data_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SolidusUsps::DomesticRatesSearchData do
-  subject { described_class.new(spree_package) }
+  subject { described_class.new(calculator, spree_package) }
 
   let(:stock_location) { create(:stock_location, zipcode: '45678') }
   let(:order) { create(:order, ship_address: create(:address, zipcode: '12345')) }
@@ -13,6 +13,8 @@ RSpec.describe SolidusUsps::DomesticRatesSearchData do
     order: order,
     variant: variant
   )}
+
+  let(:calculator) { SolidusUsps::Calculator::PriorityMail.new }
 
   let(:spree_package) do
     build(:stock_package, stock_location: stock_location).tap do |package|
@@ -29,7 +31,7 @@ RSpec.describe SolidusUsps::DomesticRatesSearchData do
         'length' => nil,
         'width' => nil,
         'height' => nil,
-        'mailClass' => nil,
+        'mailClass' => 'PRIORITY_MAIL',
         'processingCategory' => nil,
         'rateIndicator' => nil,
         'destinationEntryFacilityType' => nil,

--- a/spec/lib/solidus_usps/international_rates_search_data_spec.rb
+++ b/spec/lib/solidus_usps/international_rates_search_data_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SolidusUsps::InternationalRatesSearchData do
-  subject { described_class.new(spree_package) }
+  subject { described_class.new(calculator, spree_package) }
 
   let(:stock_location) { create(:stock_location, zipcode: '45678') }
   let(:order) { create(:order, ship_address: address) }
@@ -14,6 +14,8 @@ RSpec.describe SolidusUsps::InternationalRatesSearchData do
     order: order,
     variant: variant
   )}
+
+  let(:calculator) { SolidusUsps::Calculator::FirstClassPackageInternational.new }
 
   let(:spree_package) do
     build(:stock_package, stock_location: stock_location).tap do |package|
@@ -29,7 +31,7 @@ RSpec.describe SolidusUsps::InternationalRatesSearchData do
         'length' => nil,
         'width' => nil,
         'height' => nil,
-        'mailClass' => nil,
+        'mailClass' => 'FIRST-CLASS_PACKAGE_INTERNATIONAL_SERVICE',
         'processingCategory' => nil,
         'rateIndicator' => nil,
         'destinationEntryFacilityType' => nil,


### PR DESCRIPTION
The USPS API requires a mail_class for its prices requests. Since we've got a calculator per shipping method, we can have each calculator define what mail class it should be and pass it along to our search data so that it is available for the API request.

All values pulled from the USPS API documentation for domestic and international prices, which can be found here:

- [Domestic Prices v3](https://developers.usps.com/domesticpricesv3#tag/Resources/operation/post-base-rates-search)
- [International Prices v3](https://developers.usps.com/internationalpricesv3#tag/Resources/operation/get-international-base-rates-search)
