### PR TITLE
Clean-up install generator

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_usps.js
+++ b/app/assets/javascripts/spree/backend/solidus_usps.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'

--- a/app/assets/javascripts/spree/frontend/solidus_usps.js
+++ b/app/assets/javascripts/spree/frontend/solidus_usps.js
@@ -1,2 +1,0 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'

--- a/app/assets/stylesheets/spree/backend/solidus_usps.css
+++ b/app/assets/stylesheets/spree/backend/solidus_usps.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/backend/all.css'
-*/

--- a/app/assets/stylesheets/spree/frontend/solidus_usps.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_usps.css
@@ -1,4 +1,0 @@
-/*
-Placeholder manifest file.
-the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
-*/

--- a/lib/generators/solidus_usps/install/install_generator.rb
+++ b/lib/generators/solidus_usps/install/install_generator.rb
@@ -26,6 +26,14 @@ module SolidusUsps
           puts 'Skipping bin/rails db:migrate, don\'t forget to run it!' # rubocop:disable Rails/Output
         end
       end
+
+      def include_seeds
+        if ['', 'y', 'Y'].include?(ask('Would you like to have seed data populated now? [Y/n]'))
+          SolidusUsps::Engine.load_seed
+        else
+          puts "Skipping seeds. Don't forget to create the necessary shipping categories!"
+        end
+      end
     end
   end
 end

--- a/lib/generators/solidus_usps/install/install_generator.rb
+++ b/lib/generators/solidus_usps/install/install_generator.rb
@@ -14,16 +14,6 @@ module SolidusUsps
         template 'initializer.rb', 'config/initializers/solidus_usps.rb'
       end
 
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_usps\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_usps\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_usps\n", before: %r{\*/}, verbose: true # rubocop:disable Layout/LineLength
-        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_usps\n", before: %r{\*/}, verbose: true # rubocop:disable Layout/LineLength
-      end
-
       def add_migrations
         run 'bin/rails railties:install:migrations FROM=solidus_usps'
       end


### PR DESCRIPTION
Couple of small changes to clean-up the install generator:

1. Remove the placeholder assets. We don't have any JS or CSS in this extension. So we can skip trying to have those files required after installation.
2. Ask if we should load seed data for the user. This will create the necessary MediaMail shipping category for stores that don't already have one.
