### PR TITLE
Hardcode rate indicator to "SP" (single piece)

### DIFF
--- a/lib/solidus_usps/base_rates_search_data.rb
+++ b/lib/solidus_usps/base_rates_search_data.rb
@@ -19,10 +19,6 @@ module SolidusUsps
       "RETAIL"
     end
 
-    def rate_indicator
-      @calculator.rate_indicator
-    end
-
     def weight
       @spree_package.weight
     end

--- a/lib/solidus_usps/calculator/base.rb
+++ b/lib/solidus_usps/calculator/base.rb
@@ -11,10 +11,6 @@ module SolidusUsps
         raise NotImplementedError, "Subclasses must implement the mail_class method"
       end
 
-      def rate_indicator
-        raise NotImplementedError, "Subclasses must implement the rate_indicator method"
-      end
-
       def search_data_class
         raise NotImplementedError, "Subclasses must implement the search_data_class method"
       end

--- a/lib/solidus_usps/calculator/first_class_package_international.rb
+++ b/lib/solidus_usps/calculator/first_class_package_international.rb
@@ -3,23 +3,20 @@
 module SolidusUsps
   module Calculator
     class FirstClassPackageInternational < SolidusUsps::Calculator::Base
+      # Taken from the limit in solidus_active_shipping.
+      MAXIMUM_WEIGHT = 64
+
       def compute_package(package)
         client = SolidusUsps::InternationalPricesClient.new
         client.get_rates(rates_search_data(package))
       end
 
       def available? package
-        ship_to_country_code(package) == 'US' && package.weight <= 4 && super
+        ship_to_country_code(package) != 'US' && package.weight <= MAXIMUM_WEIGHT && super
       end
 
       def mail_class
         "FIRST-CLASS_PACKAGE_INTERNATIONAL_SERVICE"
-      end
-
-      def rate_indicator
-        # From the USPS API docs:
-        # LE - Single-piece parcel
-        "LE"
       end
 
       private

--- a/lib/solidus_usps/calculator/ground_advantage.rb
+++ b/lib/solidus_usps/calculator/ground_advantage.rb
@@ -22,12 +22,6 @@ module SolidusUsps
         "USPS_GROUND_ADVANTAGE"
       end
 
-      def rate_indicator
-        # From the USPS API docs:
-        # SP - Single Piece
-        "SP"
-      end
-
       private
 
       def ship_to_country_code(package)

--- a/lib/solidus_usps/calculator/media_mail.rb
+++ b/lib/solidus_usps/calculator/media_mail.rb
@@ -20,12 +20,6 @@ module SolidusUsps
         "MEDIA_MAIL"
       end
 
-      def rate_indicator
-        # From the USPS API docs:
-        # SP - Single Piece
-        "SP"
-      end
-
       private
 
       def shipping_category_name(item)

--- a/lib/solidus_usps/calculator/priority_mail.rb
+++ b/lib/solidus_usps/calculator/priority_mail.rb
@@ -16,12 +16,6 @@ module SolidusUsps
         "PRIORITY_MAIL"
       end
 
-      def rate_indicator
-        # From the USPS API docs:
-        # SP - Single Piece
-        "SP"
-      end
-
       private
 
       def ship_to_country_code(package)

--- a/lib/solidus_usps/domestic_rates_search_data.rb
+++ b/lib/solidus_usps/domestic_rates_search_data.rb
@@ -10,7 +10,7 @@ module SolidusUsps
         'height' => 0,
         'mailClass' => mail_class,
         'processingCategory' => "NONSTANDARD", # Because we have no dimensions, everything is non-standard.
-        'rateIndicator' => rate_indicator,
+        'rateIndicator' => "SP", # Single Piece - From the USPS API docs.
         'destinationEntryFacilityType' => "NONE",
         'priceType' => price_type,
         'mailingDate' => Date.tomorrow.to_s

--- a/lib/solidus_usps/international_rates_search_data.rb
+++ b/lib/solidus_usps/international_rates_search_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusUsps
   class InternationalRatesSearchData < BaseRatesSearchData
     def to_json
@@ -9,7 +11,7 @@ module SolidusUsps
         'height' => 0,
         'mailClass' => mail_class,
         'processingCategory' => "NONSTANDARD", # Because we have no dimensions, everything is non-standard.
-        'rateIndicator' => rate_indicator,
+        'rateIndicator' => "SP",
         'destinationEntryFacilityType' => "NONE",
         'priceType' => price_type,
         'mailingDate' => Date.tomorrow.to_s,

--- a/spec/lib/solidus_usps/calculator/first_class_package_international_spec.rb
+++ b/spec/lib/solidus_usps/calculator/first_class_package_international_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe SolidusUsps::Calculator::FirstClassPackageInternational do
   end
 
   describe "#available?" do
-    context "shipping to the US" do
-      context "with a package weight of 4 or less" do
+    context "shipping to Canada" do
+      let(:iso) { "CA" }
+
+      context "with a package weight of 64 or less" do
         before do
           order.variants.each { |variant| variant.update!(weight: 2) }
         end
@@ -39,9 +41,9 @@ RSpec.describe SolidusUsps::Calculator::FirstClassPackageInternational do
         end
       end
 
-      context "with a package weight over 4" do
+      context "with a package weight over 64" do
         before do
-          order.variants.each { |variant| variant.update!(weight: 5) }
+          order.variants.each { |variant| variant.update!(weight: 65) }
         end
 
         it "is unavailable" do
@@ -51,7 +53,7 @@ RSpec.describe SolidusUsps::Calculator::FirstClassPackageInternational do
     end
 
     context "shipping internationally" do
-      let(:iso) { 'CA' }
+      let(:iso) { 'US' }
 
       it "is unavailable" do
         expect(calculator.available?(spree_package)).to eq false

--- a/spec/lib/solidus_usps/international_rates_search_data_spec.rb
+++ b/spec/lib/solidus_usps/international_rates_search_data_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SolidusUsps::InternationalRatesSearchData do
         'height' => 0,
         'mailClass' => 'FIRST-CLASS_PACKAGE_INTERNATIONAL_SERVICE',
         'processingCategory' => 'NONSTANDARD',
-        'rateIndicator' => "LE",
+        'rateIndicator' => "SP",
         'destinationEntryFacilityType' => 'NONE',
         'priceType' => "RETAIL",
         'mailingDate' => Date.tomorrow.to_s,


### PR DESCRIPTION
Using "LE" for first-class international caused an error in the API, but "SP" works so we'll just use that for everything. Which allows us to simplify some of our code a little bit.

Also updated the international calculator to only work for non-US addresses and increased the weight limit based on what was used in the old solidus_active_shipping gem.
