### PR TITLE
Refactor #compute_package to the base calculator

### DIFF
--- a/lib/solidus_usps/calculator/base.rb
+++ b/lib/solidus_usps/calculator/base.rb
@@ -1,18 +1,40 @@
 module SolidusUsps
   module Calculator
     class Base < Spree::ShippingCalculator
-      def rates_search_data(spree_package)
-        search_data_class.new(self, spree_package)
+      def compute_package(package)
+        client.get_rates(rates_search_data(package))["totalBasePrice"]
       end
 
       private
 
-      def mail_class
-        raise NotImplementedError, "Subclasses must implement the mail_class method"
+      def client
+        case geo_group
+        when :international
+          SolidusUsps::InternationalPricesClient.new
+        when :domestic
+          SolidusUsps::DomesticPricesClient.new
+        else
+          raise "Invalid geo_group"
+        end
       end
 
       def search_data_class
-        raise NotImplementedError, "Subclasses must implement the search_data_class method"
+        case geo_group
+        when :international
+          SolidusUsps::InternationalRatesSearchData
+        when :domestic
+          SolidusUsps::DomesticRatesSearchData
+        else
+          raise "Invalid geo_group"
+        end
+      end
+
+      def rates_search_data(spree_package)
+        search_data_class.new(self, spree_package)
+      end
+
+      def mail_class
+        raise NotImplementedError, "Subclasses must implement the mail_class method"
       end
     end
   end

--- a/lib/solidus_usps/calculator/first_class_package_international.rb
+++ b/lib/solidus_usps/calculator/first_class_package_international.rb
@@ -6,11 +6,6 @@ module SolidusUsps
       # Taken from the limit in solidus_active_shipping.
       MAXIMUM_WEIGHT = 64
 
-      def compute_package(package)
-        client = SolidusUsps::InternationalPricesClient.new
-        client.get_rates(rates_search_data(package))
-      end
-
       def available? package
         ship_to_country_code(package) != 'US' && package.weight <= MAXIMUM_WEIGHT && super
       end
@@ -21,12 +16,12 @@ module SolidusUsps
 
       private
 
-      def ship_to_country_code(package)
-        package.order.ship_address.country.iso
+      def geo_group
+        :international
       end
 
-      def search_data_class
-        SolidusUsps::InternationalRatesSearchData
+      def ship_to_country_code(package)
+        package.order.ship_address.country.iso
       end
     end
   end

--- a/lib/solidus_usps/calculator/ground_advantage.rb
+++ b/lib/solidus_usps/calculator/ground_advantage.rb
@@ -9,11 +9,6 @@ module SolidusUsps
       # parcel so we may need to update this value.
       MAXIMUM_WEIGHT = 13
 
-      def compute_package(package)
-        client = SolidusUsps::DomesticPricesClient.new
-        client.get_rates(rates_search_data(package))
-      end
-
       def available? package
         ship_to_country_code(package) == 'US' && package.weight <= MAXIMUM_WEIGHT && super
       end
@@ -24,12 +19,12 @@ module SolidusUsps
 
       private
 
-      def ship_to_country_code(package)
-        package.order.ship_address.country.iso
+      def geo_group
+        :domestic
       end
 
-      def search_data_class
-        SolidusUsps::DomesticRatesSearchData
+      def ship_to_country_code(package)
+        package.order.ship_address.country.iso
       end
     end
   end

--- a/lib/solidus_usps/calculator/media_mail.rb
+++ b/lib/solidus_usps/calculator/media_mail.rb
@@ -5,11 +5,6 @@ module SolidusUsps
     class MediaMail < SolidusUsps::Calculator::Base
       CATEGORY_NAME = "Media Mail"
 
-      def compute_package(package)
-        client = SolidusUsps::DomesticPricesClient.new
-        client.get_rates(rates_search_data(package))
-      end
-
       def available?(package)
         package.contents.all? do |item|
           shipping_category_name(item) == CATEGORY_NAME
@@ -22,12 +17,12 @@ module SolidusUsps
 
       private
 
-      def shipping_category_name(item)
-        item.variant.product.shipping_category&.name
+      def geo_group
+        :domestic
       end
 
-      def search_data_class
-        SolidusUsps::DomesticRatesSearchData
+      def shipping_category_name(item)
+        item.variant.product.shipping_category&.name
       end
     end
   end

--- a/lib/solidus_usps/calculator/priority_mail.rb
+++ b/lib/solidus_usps/calculator/priority_mail.rb
@@ -3,11 +3,6 @@
 module SolidusUsps
   module Calculator
     class PriorityMail < SolidusUsps::Calculator::Base
-      def compute_package(package)
-        client = SolidusUsps::DomesticPricesClient.new
-        client.get_rates(rates_search_data(package))
-      end
-
       def available? package
         ship_to_country_code(package) == 'US' || package.weight > 4
       end
@@ -18,12 +13,12 @@ module SolidusUsps
 
       private
 
-      def ship_to_country_code(package)
-        package.order.ship_address.country.iso
+      def geo_group
+        :domestic
       end
 
-      def search_data_class
-        SolidusUsps::DomesticRatesSearchData
+      def ship_to_country_code(package)
+        package.order.ship_address.country.iso
       end
     end
   end


### PR DESCRIPTION
We're performing the same operation for every calculator, just changing the client and search data based on whether or not we need international or domestic rates.

This moves all of the logic to the base and has each calculator define a geo_group to specify whether it needs the international or domestic pricing.

Also updates our calculators to return the amount, instead of the full API request response which isn't useful for calculations up the line in Solidus.
