### PR TITLE
Remove minimum weight requirements

### DIFF
--- a/lib/solidus_usps/calculator/priority_mail_express_international.rb
+++ b/lib/solidus_usps/calculator/priority_mail_express_international.rb
@@ -3,10 +3,8 @@
 module SolidusUsps
   module Calculator
     class PriorityMailExpressInternational < SolidusUsps::Calculator::Base
-      MINIMUM_WEIGHT = 4
-
       def available? package
-        ship_to_country_code(package) != 'US' && package.weight >= MINIMUM_WEIGHT && super
+        ship_to_country_code(package) != 'US' && super
       end
 
       def mail_class

--- a/lib/solidus_usps/calculator/priority_mail_international.rb
+++ b/lib/solidus_usps/calculator/priority_mail_international.rb
@@ -3,10 +3,8 @@
 module SolidusUsps
   module Calculator
     class PriorityMailInternational < SolidusUsps::Calculator::Base
-      MINIMUM_WEIGHT = 4
-
       def available? package
-        ship_to_country_code(package) != 'US' && package.weight >= MINIMUM_WEIGHT && super
+        ship_to_country_code(package) != 'US' && super
       end
 
       def mail_class

--- a/spec/lib/solidus_usps/calculator/priority_mail_express_international_spec.rb
+++ b/spec/lib/solidus_usps/calculator/priority_mail_express_international_spec.rb
@@ -43,20 +43,8 @@ RSpec.describe SolidusUsps::Calculator::PriorityMailExpressInternational do
     context "when shipping internationally" do
       let(:order) { create(:order, ship_address: create(:address, country: create(:country, iso: 'CA'))) }
 
-      context "when the package weight is below 4 lbs" do
-        let(:variant) { create(:variant, weight: 3.0) }
-
-        it "returns false" do
-          expect(calculator.available?(spree_package)).to be false
-        end
-      end
-
-      context "when the package weight is 4 lbs or above" do
-        let(:variant) { create(:variant, weight: 5.0) }
-
-        it "returns true" do
-          expect(calculator.available?(spree_package)).to be true
-        end
+      it "returns true" do
+        expect(calculator.available?(spree_package)).to be true
       end
     end
   end

--- a/spec/lib/solidus_usps/calculator/priority_mail_international_spec.rb
+++ b/spec/lib/solidus_usps/calculator/priority_mail_international_spec.rb
@@ -29,20 +29,8 @@ RSpec.describe SolidusUsps::Calculator::PriorityMailInternational do
       let(:canada) { Spree::Country.find_or_create_by(iso: 'CA', name: 'Canada') }
       let(:order) { create(:order, ship_address: create(:address, country: canada)) }
 
-      context "when package weight is less than 4" do
-        let(:variant) { create(:variant, weight: 3.9) }
-
-        it "returns false" do
-          expect(calculator.available?(spree_package)).to be false
-        end
-      end
-
-      context "when package weight is 4 or more" do
-        let(:variant) { create(:variant, weight: 4.0) }
-
-        it "returns true" do
-          expect(calculator.available?(spree_package)).to be true
-        end
+      it "returns true" do
+        expect(calculator.available?(spree_package)).to be true
       end
     end
   end


### PR DESCRIPTION
We incorrectly added these based on a misunderstanding of USPS's offerings. On their page they say:

> You have a package that weighs over 4 lbs.

And we interpreted that to mean that priority mail was only for packages over that weight. Turns out they just meant that you couldn't use first-class package international. There's no minimum weight requirement for these options. (Other than greater than zero.)
